### PR TITLE
Don't check for identical attributes (fixes #10)

### DIFF
--- a/tests/testthat/test_custom_functions.R
+++ b/tests/testthat/test_custom_functions.R
@@ -43,6 +43,6 @@ test_that('cell_to_line returns correctly - data.frame with list-column', {
   expect_equal(ncol(val2), 3)
   expect_equal(nrow(val2), 6)
   ins <- sf::st_set_geometry(val2, NULL) # wierd behav when lib() missing
-  expect_identical(ins, paths_df)
+  expect_equal(ins, paths_df, check.attributes = FALSE)
   expect_is(val2$geometry, 'sfc_LINESTRING')
 })


### PR DESCRIPTION
This PR fixes #10 by no longer checking that attributes on newly created sf objects are identical to those created by older versions of the package.